### PR TITLE
Fix theme meta path; fix handling `not found` status from api

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -153,8 +153,8 @@ class Manager
             }
 
             if (is_dir($this->settings->themes . DIRECTORY_SEPARATOR . $value)) {
-                if (file_exists($this->settings->themes . DIRECTORY_SEPARATOR . $value . DIRECTORY_SEPARATOR . "index.php")) {
-                    $themes[$value] = $value;
+                if (file_exists($this->settings->themes . DIRECTORY_SEPARATOR . $value . DIRECTORY_SEPARATOR . "style.css")) {
+                    $themes[$value] = $value . DIRECTORY_SEPARATOR . "style.css";
                 }
             }
         }
@@ -429,7 +429,7 @@ class Manager
         $vulnerabilities = $this->get($themeName, $this->settings->token, 'themes');
 
         if (!isset($vulnerabilities[$themeName])) {
-            throw new \Exception($vulnerabilities["error"], 1);
+            throw new \Exception($vulnerabilities["status"], 1);
         }
 
         $vulnerabilities[$themeName] = $this->checkVulnerabilityWithVersion($vulnerabilities[$themeName], $meta['Version']);
@@ -464,7 +464,7 @@ class Manager
         $vulnerabilities = $this->get($pluginName, $this->settings->token);
 
         if (!isset($vulnerabilities[$pluginName])) {
-            throw new \Exception($vulnerabilities["error"], 1);
+            throw new \Exception($vulnerabilities["status"], 1);
         }
 
         $vulnerabilities[$pluginName] = $this->checkVulnerabilityWithVersion($vulnerabilities[$pluginName], $meta['Version']);


### PR DESCRIPTION
Fix theme meta path. It should be `themename/style.css`
```
Warning: fopen(C:/www/wp\wp-content\themes\twentytwenty): failed to open stream: Permission denied in C:\www\wp-vulnerability-check\src\Manager.php on line 535
```

Fix handling `not found` status from API. If plugin or theme not found API returns `status = "plugin not found"` or `status = "theme not found"`
```
Notice: Undefined index: error in C:\www\wp-vulnerability-check\wp-vulnerability-check\src\Manager.php on line 468
```