### PR TITLE
Fix comparing version strings

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -380,7 +380,7 @@ class Manager
     public function checkVulnerabilityWithVersion($result, $version)
     {
         foreach ($result['vulnerabilities'] as $key => $value) {
-            if ($version > $value['fixed_in']) {
+            if ($value['fixed_in'] && version_compare($version, $value['fixed_in'], '>=')) {
                 unset($result['vulnerabilities'][$key]);
             }
         }


### PR DESCRIPTION
Use version_compare() to compare version strings.
```php
var_dump('2.9.6' > '2.9.14'); // bool(true)
var_dump(version_compare('2.9.6', '2.9.14', '>=')); // bool(false)
```
Also check if fixed_in has a value. null means that plugin has not yet been fixed.