### PR TITLE
Scan plugins in a wordpress way

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -18,7 +18,7 @@ class Manager
 
     /**
      * Main check function
-     * 
+     *
      * @param Settings|null $settings
      * @param Output|null $output
      * @return bool
@@ -53,9 +53,9 @@ class Manager
 
    /**
     * Check if the directory exists
-    * 
+    *
     * @param string $directory
-    * 
+    *
     * @throws Exception\NotExistsPath
     */
     private function checkDirectory($directory, Output $output = null)
@@ -66,7 +66,7 @@ class Manager
                 $output->writeLine("Invalid folder ($directory) is given.");
                 $output->writeNewLine();
             }
-            
+
             throw new \Exception("Invalid folder ($directory) is given.");
         }
     }
@@ -166,7 +166,7 @@ class Manager
         $vulnerableThemes = 0;
         $totalThemeCount  = count($themes);
         $failResult       = array();
-        
+
         $output->setTotalPluginCount($totalThemeCount);
         $output->writeNewLine();
         $output->writeLine(
@@ -191,7 +191,7 @@ class Manager
                     $output->ok(); // For success
                     continue;
                 }
-                
+
                 $results      = array_merge($results, $vulResult);
             } catch (\Exception $e) {
                 $output->ok(); // Fail but means no vuşnerability in DB or custom plugin
@@ -247,32 +247,10 @@ class Manager
     {
         $this->checkDirectory($this->settings->plugins, $output);
 
-        $files   = scandir($this->settings->plugins);
-
-        if (is_dir($this->settings->MUPlugins)) {
-           $MUFiles   = scandir($this->settings->MUPlugins);
-           
-           if ($MUFiles !== false) {
-                $files = array_merge($files, $MUFiles);
-           } 
-        }
-
-        $plugins = array();
-        foreach ($files as $key => $value) {
-            if (!$this->isComponent($value)) {
-                continue;
-            }
-
-            if (is_dir($this->settings->plugins . DIRECTORY_SEPARATOR . $value)) {
-                if (file_exists($this->settings->plugins . DIRECTORY_SEPARATOR . $value . DIRECTORY_SEPARATOR . $value . ".php")) {
-                    $plugins[$value] = $value . DIRECTORY_SEPARATOR . $value . ".php";
-                }
-                
-                continue;
-            }
-
-            $plugins[str_replace('.php', '', $value)] = $value;
-        }
+        $plugins = array_merge(
+            $this->getPlugins($this->settings->plugins),
+            $this->getMuPlugins($this->settings->MUPlugins)
+        );
 
         /** @var Result[] $results */
         $results           = array();
@@ -281,17 +259,17 @@ class Manager
         $vulnerablePlugins = 0;
         $totalPluginCount  = count($plugins);
         $failResult        = array();
-        
+
         $output->setTotalPluginCount($totalPluginCount);
         $output->writeNewLine();
         $output->writeLine(
             "Checking " . ($totalPluginCount === 1 ? 'plugin' : 'plugins') . "..."
         );
         $output->writeNewLine();
-        foreach ($plugins as $plugin => $file) {
+        foreach ($plugins as $plugin => $meta) {
             try {
                 $checkedPlugins++;
-                $vulResult = $this->checkPlugin($plugin, $file, $this->settings);
+                $vulResult = $this->checkPlugin($plugin, $meta, $this->settings);
 
                 if (!isset($vulResult[$plugin])) {
                     $output->ok(); // For success
@@ -306,7 +284,7 @@ class Manager
                     $output->ok(); // For success
                     continue;
                 }
-                
+
                 $results      = array_merge($results, $vulResult);
             } catch (\Exception $e) {
                 $output->ok(); // Fail but means no vuşnerability in DB or custom plugin
@@ -352,7 +330,7 @@ class Manager
 
     /**
      * Return true if the filename is most probably a plugin
-     * 
+     *
      * @param string $plugin File name
      * @return boolean
      */
@@ -441,26 +419,17 @@ class Manager
      * Check plugin with plugin name via API
      *
      * @param string $pluginName
-     * @param string $pluginFile
+     * @param array $meta
      * @param Settings $settings
      * @return Result[]
      * @throws Exception
      */
-    public function checkPlugin($pluginName, $pluginFile, Settings $settings = null)
+    public function checkPlugin($pluginName, $meta, Settings $settings = null)
     {
         if ($settings instanceof Settings) {
             $this->settings = $settings;
         }
 
-        $plugin   = $this->settings->plugins . DIRECTORY_SEPARATOR . $pluginFile;
-        $MUPlugin = $this->settings->MUPlugins . DIRECTORY_SEPARATOR . $pluginFile;
-
-        if (file_exists($plugin)) {
-            $meta = $this->getPluginMetaData($plugin);
-        } else if (file_exists($MUPlugin)) {
-            $meta = $this->getPluginMetaData($MUPlugin);
-        }
-        
         $vulnerabilities = $this->get($pluginName, $this->settings->token);
 
         if (!isset($vulnerabilities[$pluginName])) {
@@ -474,9 +443,9 @@ class Manager
 
     /**
      * Get theme meta data from the header comment block
-     * 
+     *
      * @param string $file File path of the plugin file
-     * @return array The array of the meta values 
+     * @return array The array of the meta values
      */
     private function getThemeMetaData($file)
     {
@@ -493,15 +462,15 @@ class Manager
            // Site Wide Only is deprecated in favor of Network.
            '_sitewide'   => 'Site Wide Only'
          );
-        
+
         return $this->getFileMetaData($all_headers, $file);
     }
 
     /**
      * Get plugin meta data from the header comment block
-     * 
+     *
      * @param string $file File path of the plugin file
-     * @return array The array of the meta values 
+     * @return array The array of the meta values
      */
     private function getPluginMetaData($file)
     {
@@ -518,37 +487,37 @@ class Manager
            // Site Wide Only is deprecated in favor of Network.
            '_sitewide'   => 'Site Wide Only'
          );
-        
+
         return $this->getFileMetaData($all_headers, $file);
     }
 
     /**
      * Get file meta data from the header comment block
-     * 
+     *
      * @param string $file File path of the plugin file
-     * @return array The array of the meta values 
+     * @return array The array of the meta values
      */
     private function getFileMetaData($headers, $file)
     {
         // We don't need to write to the file, so just open for reading.
         $fp = fopen($file, 'r');
-     
+
         // Pull only the first 8kiB of the file in.
         $file_data = fread($fp, 8192);
-     
+
         // PHP will close file handle, but we are good citizens.
         fclose($fp);
-     
+
         // Make sure we catch CR-only line endings.
         $file_data = str_replace("\r", "\n", $file_data);
-     
+
         foreach ($headers as $field => $regex) {
             if (preg_match( '/^[ \t\/*#@]*' . preg_quote($regex, '/') . ':(.*)$/mi', $file_data, $match) && $match[1])
                 $headers[$field] = trim(preg_replace("/\s*(?:\*\/|\?>).*/", '', $match[1]));
             else
                 $headers[$field] = '';
         }
-     
+
         return $headers;
     }
 
@@ -583,7 +552,7 @@ class Manager
 
     /**
      * Print result list
-     * 
+     *
      * @param array $results
      * @param Output $output
      * @return void
@@ -601,6 +570,152 @@ class Manager
                 continue;
             }
             $output->writeResult($plugin, $vulnerabilities['vulnerabilities']);
+        }
+    }
+
+    /**
+     * Check the plugins directory and retrieve all plugin files with plugin data.
+     *
+     * WordPress only supports plugin files in the base plugins directory
+     * (wp-content/plugins) and in one directory above the plugins directory
+     * (wp-content/plugins/my-plugin). The file it looks for has the plugin data
+     * and must be found in those two locations.
+     *
+     * @param string $pluginRoot Absolute path to plugins folder.
+     * @return array[] Array of arrays of plugin data, keyed by plugin file name. See `get_plugin_data()`.
+     */
+    private function getPlugins($pluginRoot)
+    {
+        $wpPlugins  = array();
+
+        // Files in wp-content/plugins directory.
+        $pluginsDir = @opendir($pluginRoot);
+        $pluginFiles = array();
+
+        if ($pluginsDir) {
+            while (($file = readdir($pluginsDir)) !== false) {
+                if ('.' === substr($file, 0, 1)) {
+                    continue;
+                }
+
+                if (is_dir($pluginRoot . '/' . $file)) {
+                    $pluginsSubdir = @opendir($pluginRoot . '/' . $file);
+
+                    if ($pluginsSubdir) {
+                        while (($subfile = readdir($pluginsSubdir)) !== false) {
+                            if ('.' === substr($subfile, 0, 1)) {
+                                continue;
+                            }
+
+                            if ('.php' === substr($subfile, -4)) {
+                                $pluginFiles[] = "$file/$subfile";
+                            }
+                        }
+
+                        closedir($pluginsSubdir);
+                    }
+                } else {
+                    if ('.php' === substr($file, -4)) {
+                        $pluginFiles[] = $file;
+                    }
+                }
+            }
+
+            closedir($pluginsDir);
+        }
+
+        if (empty($pluginFiles)) {
+            return $wpPlugins;
+        }
+
+        foreach ($pluginFiles as $pluginFile) {
+            if (!is_readable("$pluginRoot/$pluginFile")) {
+                continue;
+            }
+
+            $pluginData = $this->getPluginMetaData("$pluginRoot/$pluginFile");
+
+            if (empty($pluginData['Name'])) {
+                continue;
+            }
+
+            $wpPlugins[$this->pluginBasename($pluginFile)] = $pluginData;
+        }
+
+        return $wpPlugins;
+    }
+
+    /**
+     * Check the mu-plugins directory and retrieve all mu-plugin files with any plugin data.
+     *
+     * WordPress only includes mu-plugin files in the base mu-plugins directory (wp-content/mu-plugins).
+     *
+     * @param string $muPluginRoot Absolute path to mu-plugins folder.
+     * @return array[] Array of arrays of mu-plugin data, keyed by plugin file name.
+     */
+    private function getMuPlugins($muPluginRoot)
+    {
+        $wpPlugins = array();
+        $pluginFiles = array();
+
+        if (!is_dir($muPluginRoot)) {
+            return $wpPlugins;
+        }
+
+        // Files in wp-content/mu-plugins directory.
+        $pluginsDir = @opendir($muPluginRoot);
+        if ($pluginsDir) {
+            while (($file = readdir($pluginsDir)) !== false) {
+                if ('.php' === substr($file, -4)) {
+                    $pluginFiles[] = $file;
+                }
+            }
+        } else {
+            return $wpPlugins;
+        }
+
+        closedir($pluginsDir);
+
+        if (empty($pluginFiles)) {
+            return $wpPlugins;
+        }
+
+        foreach ($pluginFiles as $pluginFile) {
+            if (!is_readable($muPluginRoot . "/$pluginFile")) {
+                continue;
+            }
+
+            $pluginData = $this->getPluginMetaData($muPluginRoot . "/$pluginFile");
+
+            if (empty($pluginData['Name'])) {
+                $pluginData['Name'] = $pluginFile;
+            }
+
+            $wpPlugins[$pluginFile] = $pluginData;
+        }
+
+        if (isset($wpPlugins['index.php']) && filesize($muPluginRoot . '/index.php') <= 30) {
+            // Silence is golden.
+            unset($wpPlugins['index.php']);
+        }
+
+        return $wpPlugins;
+    }
+
+    /**
+     * Gets the basename of a plugin.
+     *
+     * This method extracts the name of a plugin from its filename.
+     *
+     * @param string $pluginFile The filename of plugin.
+     * @return string The name of a plugin.
+     */
+    private function pluginBasename($pluginFile)
+    {
+        if (false === strpos($pluginFile, '/')) {
+            return basename($pluginFile, '.php');
+        } else {
+            return dirname($pluginFile);
         }
     }
 }


### PR DESCRIPTION
I refactored plugins scanning using adapted version of `get_plugins` and `get_mu_plugins` from `wp-admin/includes/plugin.php`.
This fixes the problem with plugins whose main file is not named after a folder. For example popular WP Mail SMTP plugin has files:
```
wp-mail-smtp/wp-mail-smtp.php <= this file is checked by wp-vulnerability-check
wp-mail-smtp/wp_mail_smtp.php <= this is actually main file with header comment, meta, version etc.
```